### PR TITLE
Added support for Symfony 2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "doctrine/orm": "~2.2,>=2.2.3",
-    "symfony/symfony": "~2.6.1",
+    "symfony/symfony": "~2.6.1|~2.7.0",
     "sonata-project/media-bundle": "~2.3"
   },
   "suggest": {


### PR DESCRIPTION
Symfony 2.6 contains security issues that will not be fixed, like [CVE-2016-4423](http://symfony.com/blog/cve-2016-4423-large-username-storage-in-session)

Updating symfony from 2.6 to 2.7 (an LTS, although not the latest) results in an error. 

```
$ composer update symfony/symfony
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - socialbit/sonatamediatwigextension-bundle 1.0.x-dev requires symfony/symfony ~2.6.1 -> satisfiable by symfony/symfony[2.6.x-dev, v2.6.1, v2.6.10, v2.6.11, v2.6.12, v2.6.13, v2.6.2, v2.6.3, v2.6.4, v2.6.5, v2.6.6, v2.6.7, v2.6.8, v2.6.9] but these conflict with your requirements or minimum-stability.
    - socialbit/sonatamediatwigextension-bundle 1.0.x-dev requires symfony/symfony ~2.6.1 -> satisfiable by symfony/symfony[2.6.x-dev, v2.6.1, v2.6.10, v2.6.11, v2.6.12, v2.6.13, v2.6.2, v2.6.3, v2.6.4, v2.6.5, v2.6.6, v2.6.7, v2.6.8, v2.6.9] but these conflict with your requirements or minimum-stability.
    - socialbit/sonatamediatwigextension-bundle 1.0.x-dev requires symfony/symfony ~2.6.1 -> satisfiable by symfony/symfony[2.6.x-dev, v2.6.1, v2.6.10, v2.6.11, v2.6.12, v2.6.13, v2.6.2, v2.6.3, v2.6.4, v2.6.5, v2.6.6, v2.6.7, v2.6.8, v2.6.9] but these conflict with your requirements or minimum-stability.
    - Installation request for socialbit/sonatamediatwigextension-bundle (locked at 1.0.x-dev, required as dev-master) -> satisfiable by socialbit/sonatamediatwigextension-bundle[1.0.x-dev].
```

We could also allow later versions of Symfony later if we're sure there are not BC incompatibilities, though there shouldn't be until at least 3.0.